### PR TITLE
feat: updated workflow to automate github and pub.dev release

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   # Check code formatting and static analysis on Ubuntu.
   analyze:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -42,3 +42,40 @@ jobs:
         run: dart pub get
       - name: Run VM tests
         run: dart test --platform vm
+
+  # release on Github and pub.dev
+  publish:
+    needs: test
+    if: github.repository == 'casbin/dart-casbin' && github.event_name == 'push'
+    runs-on: ubuntu-20.04
+    steps:    
+      - uses: actions/checkout@v2
+      - uses: cedx/setup-dart@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - run: npm install -g "@semantic-release/changelog"
+      - run: npm install -g "@semantic-release/git"
+      - run: npm install -g "pub-semantic-release"
+
+      - name: Bump version
+        run: |
+          export NODE_PATH="$(npm root -g)"
+          npx semantic-release@17
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Publish to pub
+        run: dart pub publish --dry-run
+
+      - uses: sakebook/actions-flutter-pub-publisher@v1.3.1
+        with:
+          package_directory: ${{ matrix.package }}
+          credential: ${{ secrets.PUB_CREDENTIALS }}
+          flutter_package: true
+          skip_test: true
+        
+      - name: Commit updated pubspec and changelog files
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update pubspec and changelog

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -58,7 +58,7 @@ jobs:
       - run: npm install -g "@semantic-release/git"
       - run: npm install -g "pub-semantic-release"
 
-      - name: Bump version
+      - name: Semantic Release
         run: |
           export NODE_PATH="$(npm root -g)"
           npx semantic-release@17
@@ -74,8 +74,3 @@ jobs:
           credential: ${{ secrets.PUB_CREDENTIALS }}
           flutter_package: true
           skip_test: true
-        
-      - name: Commit updated pubspec and changelog files
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Update pubspec and changelog

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,12 @@
+{
+    "debug": true,
+    "branches": [
+        "main"     
+    ],
+    "plugins": [
+        "@semantic-release/commit-analyzer",
+        "pub-semantic-release",
+        "@semantic-release/release-notes-generator",
+        "@semantic-release/github"
+    ]
+}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,12 +1,25 @@
 {
     "debug": true,
     "branches": [
-        "main"     
-    ],
+      "master"     
+      ],
     "plugins": [
-        "@semantic-release/commit-analyzer",
-        "pub-semantic-release",
-        "@semantic-release/release-notes-generator",
-        "@semantic-release/github"
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      "pub-semantic-release",
+      [
+        "@semantic-release/changelog",
+        {
+          "changelogFile": "CHANGELOG.md"
+        }
+      ],
+      [
+        "@semantic-release/git",
+        {
+          "assets": ["pubspec.yaml", "CHANGELOG.md"],
+          "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        }
+      ],
+      "@semantic-release/github"
     ]
-}
+  }


### PR DESCRIPTION
Fix: https://github.com/casbin/dart-casbin/issues/45

@hsluoyz @KNawm please review. We will need to add a secret named PUB_CREDENTIALS according to [this instruction](https://github.com/sakebook/actions-flutter-pub-publisher#credential). 